### PR TITLE
fix(package.json): Specify required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "curriculum-parser": "./index.js"
   },
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "scripts": {
     "pretest": "eslint .",
     "test": "jest test/*.spec.js --verbose --coverage"


### PR DESCRIPTION
Since you're using a Node.js built-in method such as `promisify`, which [was added since version 8](https://nodejs.org/dist/latest-v10.x/docs/api/util.html#util_util_promisify_original) and rest operator in destructuring assignment [which was supported in version 8.3](https://stackoverflow.com/a/40066910/6793452), I think it's valid to add the minimum required version of Node otherwise it will throw an error.