### PR TITLE
fix(docs): Update rubric format in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ curriculum-parser project projects/01-cipher \
   --version 2.2.0 \
   --locale es-ES \
   --track js \
-  --rubric 2 \
+  --rubric 2.x \
   > "build/projects/01-cipher.json"
 ```
 


### PR DESCRIPTION
When we run the https://github.com/Laboratoria/curriculum-parser#parse-a-project-within-the-curricula-js-repo
example it will error out to `Invalid rubric version range`
because the example uses a number that Node won't type coerce to string.

By using a semver like example we will make Node understand that
it should be a string and that `semver.validRange` will get it right.