### PR TITLE
Transformar links (Youtube + Vimeo)

### DIFF
--- a/lib/__tests__/__fixtures__/04-readme-with-vimeo-link/README.md
+++ b/lib/__tests__/__fixtures__/04-readme-with-vimeo-link/README.md
@@ -1,3 +1,8 @@
+---
+type: read
+duration: 0.5h
+---
+
 # El equipo de desarrollo
 
 - Tipo: `lectura`

--- a/lib/__tests__/linkProviders.spec.js
+++ b/lib/__tests__/linkProviders.spec.js
@@ -61,21 +61,21 @@ describe.only('parseLinks', () => {
     });
 
     // TODO: skip links with this format
-    it.skip('returns expected iframe node for vimeo link with unusual format', () => {
-      const linkNode = JSON.parse(`{"type":"link",
-        "title":null,
-        "url":"https://vimeo.com/503607618/7619450015",
-        "children":[{"type":"text","value":"Video : Other vimeo link","position":{"start":{"line":24,"column":2,"offset":580},"end":{"line":24,"column":26,"offset":604}}}],
-        "position":{
-          "start":{"line":24,"column":1,"offset":579},
-          "end":{"line":24,"column":67,"offset":645}
-        }
-      }`);
-      const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/503607618/7619450015?title=0&byline=0&portrait=0" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
-      const parsedNode = parseLinks(linkNode);
-      expect(parsedNode.value).toEqual(iframeHTML);
-    });
-    it.only('returns expected iframe node for vimeo link with query string', () => {
+    // it.skip('returns expected iframe node for vimeo link with unusual format', () => {
+    //   const linkNode = JSON.parse(`{"type":"link",
+    //     "title":null,
+    //     "url":"https://vimeo.com/503607618/7619450015",
+    //     "children":[{"type":"text","value":"Video : Other vimeo link","position":{"start":{"line":24,"column":2,"offset":580},"end":{"line":24,"column":26,"offset":604}}}],
+    //     "position":{
+    //       "start":{"line":24,"column":1,"offset":579},
+    //       "end":{"line":24,"column":67,"offset":645}
+    //     }
+    //   }`);
+    //   const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/503607618/7619450015?title=0&byline=0&portrait=0" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
+    //   const parsedNode = parseLinks(linkNode);
+    //   expect(parsedNode.value).toEqual(iframeHTML);
+    // });
+    it('returns expected iframe node for vimeo link with query string', () => {
       const linkNode = JSON.parse(`{"type":"link",
         "title":null,
         "url":"https://vimeo.com/94950270?h=e9afa939c2&title=1",

--- a/lib/__tests__/linkProviders.spec.js
+++ b/lib/__tests__/linkProviders.spec.js
@@ -3,16 +3,20 @@ import { parseLinks } from '../linkProviders.js';
 
 vi.mock('sharp');
 
-
 describe('parseLinks', () => {
   describe('Youtube', () => {
     it('returns expected iframe node for link with format youtu.be', () => {
-      const linkNode = JSON.parse(`{"type":"link",
-        "title":null,
-        "url":"https://youtu.be/ge4h5uJN6KI",
-        "children":[{"type":"image","title":null,"url":"https://lh5.googleusercontent.com/Nw1xRXhRhwllHgKL4m6xCFmPCubo7wgZ0bi7NSnRQk-FJm5AWPeJKbrF9yY3Uv8XJGbYcJhL6xDwBDkxYrf3fRjnp8__diJ8pJbnuTpD-KDTo4jXmu9QHkmjogOsOLfDpFN6AeIU9Hg","alt":"El equipo de desarrollo","position":{"start":{"line":22,"column":2,"offset":469},"end":{"line":22,"column":203,"offset":670}}}],
-        "position":{"start":{"line":22,"column":1,"offset":468},"end":{"line":22,"column":234,"offset":701}}
-      }`);
+      // node object examples were printed
+      // using JSON.stringify inside the parseLinks fn
+      // when we know its a node of type link
+      const linkNode = {
+        type: 'link',
+        title: null,
+        url: 'https://youtu.be/ge4h5uJN6KI',
+        children: [{ type: 'image', title: null, url: 'https://lh5.googleusercontent.com/Nw1xRXhRhwllHgKL4m6xCFmPCubo7wgZ0bi7NSnRQk-FJm5AWPeJKbrF9yY3Uv8XJGbYcJhL6xDwBDkxYrf3fRjnp8__diJ8pJbnuTpD-KDTo4jXmu9QHkmjogOsOLfDpFN6AeIU9Hg', alt: 'El equipo de desarrollo', position: { start: { line: 22, column: 2, offset: 469 }, end: { line: 22, column: 203, offset: 670 } } }],
+        position: { start: { line: 22, column: 1, offset: 468 },
+          end: { line: 22, column: 234, offset: 701 } },
+      };
       const iframeHTML = '<iframe width="640" height="360" src="https://www.youtube.com/embed/ge4h5uJN6KI?autoplay=0" frameBorder="0" gesture="media" allow="encrypted-media" allowfullscreen="true"></iframe>';
       const parsedNode = parseLinks(linkNode);
       expect(parsedNode.type).toEqual('html');
@@ -20,15 +24,14 @@ describe('parseLinks', () => {
     });
 
     it('returns expected iframe node for link with format youtube.com/watch?v', () => {
-      const linkNode = JSON.parse(`{"type":"link",
-        "title":null,
-        "url":"https://www.youtube.com/watch?v=BPlCatqZRPI",
-        "children":[{"type":"text","value":"Video : Youtube","position":{"start":{"line":28,"column":4,"offset":1039},"end":{"line":28,"column":19,"offset":1054}}}],
-        "position":{
-          "start":{"line":28,"column":3,"offset":1038},
-          "end":{"line":28,"column":65,"offset":1100}
-        }
-      }`);
+      const linkNode = { type: 'link',
+        title: null,
+        url: 'https://www.youtube.com/watch?v=BPlCatqZRPI',
+        children: [{ type: 'text', value: 'Video : Youtube', position: { start: { line: 28, column: 4, offset: 1039 }, end: { line: 28, column: 19, offset: 1054 } } }],
+        position: {
+          start: { line: 28, column: 3, offset: 1038 },
+          end: { line: 28, column: 65, offset: 1100 },
+        } };
       const iframeHTML = '<iframe width="640" height="360" src="https://www.youtube.com/embed/BPlCatqZRPI?autoplay=0" frameBorder="0" gesture="media" allow="encrypted-media" allowfullscreen="true"></iframe>';
       const parsedNode = parseLinks(linkNode);
       expect(parsedNode.type).toEqual('html');
@@ -46,61 +49,99 @@ describe('parseLinks', () => {
 
   describe('Vimeo', () => {
     it('returns expected iframe node for vimeo link', () => {
-      const linkNode = JSON.parse(`{"type":"link",
-        "title":null,
-        "url":"https://vimeo.com/94950270",
-        "children":[{"type":"text","value":"Video : Spotify","position":{"start":{"line":23,"column":2,"offset":534},"end":{"line":23,"column":17,"offset":549}}}],
-        "position":{
-          "start":{"line":23,"column":1,"offset":533},
-          "end":{"line":23,"column":46,"offset":578}
-        }
-      }`);
+      const linkNode = { type: 'link',
+        title: null,
+        url: 'https://vimeo.com/94950270',
+        children: [{ type: 'text', value: 'Video : Spotify', position: { start: { line: 23, column: 2, offset: 534 }, end: { line: 23, column: 17, offset: 549 } } }],
+        position: {
+          start: { line: 23, column: 1, offset: 533 },
+          end: { line: 23, column: 46, offset: 578 },
+        } };
       const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/94950270?title=0&byline=0&portrait=0" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
       const parsedNode = parseLinks(linkNode);
       expect(parsedNode.value).toEqual(iframeHTML);
     });
 
-    // TODO: skip links with this format
-    // it.skip('returns expected iframe node for vimeo link with unusual format', () => {
-    //   const linkNode = JSON.parse(`{"type":"link",
-    //     "title":null,
-    //     "url":"https://vimeo.com/503607618/7619450015",
-    //     "children":[{"type":"text",
-    //      "value":"Video : Other vimeo link",
-    //      "position":{"start":{"line":24,"column":2,"offset":580},
-    //      "end":{"line":24,"column":26,"offset":604}}}],
-    //     "position":{
-    //       "start":{"line":24,"column":1,"offset":579},
-    //       "end":{"line":24,"column":67,"offset":645}
-    //     }
-    //   }`);
-    //   const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/503607618/7619450015?title=0&byline=0&portrait=0" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
-    //   const parsedNode = parseLinks(linkNode);
-    //   expect(parsedNode.value).toEqual(iframeHTML);
-    // });
+    it('returns same node (skips iframe) for vimeo link with unusual format', () => {
+      const linkNode = { type: 'link',
+        title: null,
+        url: 'https://vimeo.com/503607618/7619450015',
+        children: [{ type: 'text',
+          value: 'Video : Other vimeo link',
+          position: { start: { line: 24, column: 2, offset: 580 },
+            end: { line: 24, column: 26, offset: 604 } } }],
+        position: {
+          start: { line: 24, column: 1, offset: 579 },
+          end: { line: 24, column: 67, offset: 645 },
+        } };
+      expect(parseLinks(linkNode)).toEqual(linkNode);
+    });
+
     it('returns expected iframe node for vimeo link with query string', () => {
-      const linkNode = JSON.parse(`{"type":"link",
-        "title":null,
-        "url":"https://vimeo.com/94950270?h=e9afa939c2&title=1",
-        "children":[{"type":"text","value":"Video : Spotify","position":{"start":{"line":22,"column":2,"offset":469},"end":{"line":22,"column":17,"offset":484}}}],
-        "position":{
-          "start":{"line":22,"column":1,"offset":468},
-          "end":{"line":22,"column":67,"offset":534}
-        }
-      }`);
-      const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/94950270?title=1&byline=0&portrait=0&h=e9afa939c2" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
+      const linkNode = { type: 'link',
+        title: null,
+        url: 'https://vimeo.com/94950270?h=e9afa939c2&title=1&foo=bar',
+        children: [{ type: 'text', value: 'Video : Spotify', position: { start: { line: 22, column: 2, offset: 469 }, end: { line: 22, column: 17, offset: 484 } } }],
+        position: {
+          start: { line: 22, column: 1, offset: 468 },
+          end: { line: 22, column: 67, offset: 534 },
+        } };
+      const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/94950270?title=1&byline=0&portrait=0&h=e9afa939c2&foo=bar" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
       const parsedNode = parseLinks(linkNode);
       expect(parsedNode.type).toEqual('html');
       expect(parsedNode.value).toEqual(iframeHTML);
     });
   });
 
-  // it('returns the same link node for links not supported by linkProviders', () => {
-  //   // wistia example
-  //   const linkNode = '';
-  //   console.log(linkNode);
-  //   expect(parseLinks(linkNode)).toEqual(linkNode);
-  // });
+  it('returns the same link node for links not supported by linkProviders', () => {
+    // wistia example
+    const linkNode = { type: 'link',
+      title: null,
+      url: 'https://laboratoria-1.wistia.com/medias/wq71jjy6kb',
+      children: [{ type: 'text', value: 'video', position: { start: { line: 22, column: 2, offset: 469 }, end: { line: 22, column: 7, offset: 474 } } }],
+      position: {
+        start: { line: 22, column: 1, offset: 468 },
+        end: { line: 22, column: 60, offset: 527 },
+      } };
+    expect(parseLinks(linkNode)).toEqual(linkNode);
+  });
+
+  it('returns the same node for links yet not supported by linkProvder with a thumbnail', () => {
+    const linkNode = { type: 'link',
+      title: null,
+      url: 'https://www.loom.com/share/2f796990c8054df793c8b61ddebf63ad',
+      children: [{ type: 'image',
+        title: null,
+        url: 'https://img.youtube.com/vi/5fzzEx7-a5k/0.jpg',
+        alt: 'Menu\nHambúrguer',
+        position: { start: { line: 22, column: 2, offset: 469 },
+          end: { line: 23, column: 58, offset: 534 } } },
+      ],
+      position: {
+        start: { line: 22, column: 1, offset: 468 },
+        end: { line: 23, column: 104, offset: 580 },
+      } };
+    expect(parseLinks(linkNode)).toEqual(linkNode);
+  });
+
+  it('returns the iframe for links supported by linkProvider with a thumbnail', () => {
+    const linkNode = { type: 'link',
+      title: null,
+      url: 'https://www.youtube.com/watch?v=5fzzEx7-a5k',
+      children: [{ type: 'image',
+        title: null,
+        url: 'https://img.youtube.com/vi/5fzzEx7-a5k/0.jpg',
+        alt: 'Menu\nHambúrguer',
+        position: { start: { line: 22, column: 2, offset: 469 },
+          end: { line: 23, column: 58, offset: 534 } } },
+      ],
+      position: {
+        start: { line: 22, column: 1, offset: 468 },
+        end: { line: 23, column: 104, offset: 580 },
+      } };
+    const iframeHTML = '<iframe width="640" height="360" src="https://www.youtube.com/embed/5fzzEx7-a5k?autoplay=0" frameBorder="0" gesture="media" allow="encrypted-media" allowfullscreen="true"></iframe>';
+    const parsedNode = parseLinks(linkNode);
+    expect(parsedNode.type).toEqual('html');
+    expect(parsedNode.value).toEqual(iframeHTML);
+  });
 });
-// what about support for
-// // [![Menu Hambúrguer](https://img.youtube.com/vi/5fzzEx7-a5k/0.jpg)](https://www.youtube.com/watch?v=5fzzEx7-a5k)

--- a/lib/__tests__/linkProviders.spec.js
+++ b/lib/__tests__/linkProviders.spec.js
@@ -65,7 +65,10 @@ describe.only('parseLinks', () => {
     //   const linkNode = JSON.parse(`{"type":"link",
     //     "title":null,
     //     "url":"https://vimeo.com/503607618/7619450015",
-    //     "children":[{"type":"text","value":"Video : Other vimeo link","position":{"start":{"line":24,"column":2,"offset":580},"end":{"line":24,"column":26,"offset":604}}}],
+    //     "children":[{"type":"text",
+    //      "value":"Video : Other vimeo link",
+    //      "position":{"start":{"line":24,"column":2,"offset":580},
+    //      "end":{"line":24,"column":26,"offset":604}}}],
     //     "position":{
     //       "start":{"line":24,"column":1,"offset":579},
     //       "end":{"line":24,"column":67,"offset":645}

--- a/lib/__tests__/linkProviders.spec.js
+++ b/lib/__tests__/linkProviders.spec.js
@@ -4,7 +4,7 @@ import { parseLinks } from '../linkProviders.js';
 vi.mock('sharp');
 
 
-describe.only('parseLinks', () => {
+describe('parseLinks', () => {
   describe('Youtube', () => {
     it('returns expected iframe node for link with format youtu.be', () => {
       const linkNode = JSON.parse(`{"type":"link",

--- a/lib/__tests__/linkProviders.spec.js
+++ b/lib/__tests__/linkProviders.spec.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseLinks } from '../linkProviders.js';
+
+vi.mock('sharp');
+
+
+describe.only('parseLinks', () => {
+  describe('Youtube', () => {
+    it('returns expected iframe node for link with format youtu.be', () => {
+      const linkNode = JSON.parse(`{"type":"link",
+        "title":null,
+        "url":"https://youtu.be/ge4h5uJN6KI",
+        "children":[{"type":"image","title":null,"url":"https://lh5.googleusercontent.com/Nw1xRXhRhwllHgKL4m6xCFmPCubo7wgZ0bi7NSnRQk-FJm5AWPeJKbrF9yY3Uv8XJGbYcJhL6xDwBDkxYrf3fRjnp8__diJ8pJbnuTpD-KDTo4jXmu9QHkmjogOsOLfDpFN6AeIU9Hg","alt":"El equipo de desarrollo","position":{"start":{"line":22,"column":2,"offset":469},"end":{"line":22,"column":203,"offset":670}}}],
+        "position":{"start":{"line":22,"column":1,"offset":468},"end":{"line":22,"column":234,"offset":701}}
+      }`);
+      const iframeHTML = '<iframe width="640" height="360" src="https://www.youtube.com/embed/ge4h5uJN6KI?autoplay=0" frameBorder="0" gesture="media" allow="encrypted-media" allowfullscreen="true"></iframe>';
+      const parsedNode = parseLinks(linkNode);
+      expect(parsedNode.type).toEqual('html');
+      expect(parsedNode.value).toEqual(iframeHTML);
+    });
+
+    it('returns expected iframe node for link with format youtube.com/watch?v', () => {
+      const linkNode = JSON.parse(`{"type":"link",
+        "title":null,
+        "url":"https://www.youtube.com/watch?v=BPlCatqZRPI",
+        "children":[{"type":"text","value":"Video : Youtube","position":{"start":{"line":28,"column":4,"offset":1039},"end":{"line":28,"column":19,"offset":1054}}}],
+        "position":{
+          "start":{"line":28,"column":3,"offset":1038},
+          "end":{"line":28,"column":65,"offset":1100}
+        }
+      }`);
+      const iframeHTML = '<iframe width="640" height="360" src="https://www.youtube.com/embed/BPlCatqZRPI?autoplay=0" frameBorder="0" gesture="media" allow="encrypted-media" allowfullscreen="true"></iframe>';
+      const parsedNode = parseLinks(linkNode);
+      expect(parsedNode.type).toEqual('html');
+      expect(parsedNode.value).toEqual(iframeHTML);
+    });
+
+    // it.skip('returns expected iframe node for link with params preserved', () => {
+    //   const linkNode = JSON.parse();
+    //   const iframeValue = '<iframe width="640" height="360" src="https://www.youtube.com/embed/BPlCatqZRPI?autoplay=0" frameBorder="0" gesture="media" allow="encrypted-media" allowfullscreen="true"></iframe>';
+    //   const parsedNode = parseLinks(linkNode);
+    //   expect(parsedNode.type).toEqual('html');
+    //   expect(parsedNode.value).toEqual(iframeValue);
+    // });
+  });
+
+  describe('Vimeo', () => {
+    it('returns expected iframe node for vimeo link', () => {
+      const linkNode = JSON.parse(`{"type":"link",
+        "title":null,
+        "url":"https://vimeo.com/94950270",
+        "children":[{"type":"text","value":"Video : Spotify","position":{"start":{"line":23,"column":2,"offset":534},"end":{"line":23,"column":17,"offset":549}}}],
+        "position":{
+          "start":{"line":23,"column":1,"offset":533},
+          "end":{"line":23,"column":46,"offset":578}
+        }
+      }`);
+      const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/94950270?title=0&byline=0&portrait=0" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
+      const parsedNode = parseLinks(linkNode);
+      expect(parsedNode.value).toEqual(iframeHTML);
+    });
+
+    // TODO: skip links with this format
+    it.skip('returns expected iframe node for vimeo link with unusual format', () => {
+      const linkNode = JSON.parse(`{"type":"link",
+        "title":null,
+        "url":"https://vimeo.com/503607618/7619450015",
+        "children":[{"type":"text","value":"Video : Other vimeo link","position":{"start":{"line":24,"column":2,"offset":580},"end":{"line":24,"column":26,"offset":604}}}],
+        "position":{
+          "start":{"line":24,"column":1,"offset":579},
+          "end":{"line":24,"column":67,"offset":645}
+        }
+      }`);
+      const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/503607618/7619450015?title=0&byline=0&portrait=0" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
+      const parsedNode = parseLinks(linkNode);
+      expect(parsedNode.value).toEqual(iframeHTML);
+    });
+    it.only('returns expected iframe node for vimeo link with query string', () => {
+      const linkNode = JSON.parse(`{"type":"link",
+        "title":null,
+        "url":"https://vimeo.com/94950270?h=e9afa939c2&title=1",
+        "children":[{"type":"text","value":"Video : Spotify","position":{"start":{"line":22,"column":2,"offset":469},"end":{"line":22,"column":17,"offset":484}}}],
+        "position":{
+          "start":{"line":22,"column":1,"offset":468},
+          "end":{"line":22,"column":67,"offset":534}
+        }
+      }`);
+      const iframeHTML = '<iframe width="640" height="360" src="https://player.vimeo.com/video/94950270?title=1&byline=0&portrait=0&h=e9afa939c2" frameBorder="0" scrolling="no" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>';
+      const parsedNode = parseLinks(linkNode);
+      expect(parsedNode.type).toEqual('html');
+      expect(parsedNode.value).toEqual(iframeHTML);
+    });
+  });
+
+  // it('returns the same link node for links not supported by linkProviders', () => {
+  //   // wistia example
+  //   const linkNode = '';
+  //   console.log(linkNode);
+  //   expect(parseLinks(linkNode)).toEqual(linkNode);
+  // });
+});
+// what about support for
+// // [![Menu Hambúrguer](https://img.youtube.com/vi/5fzzEx7-a5k/0.jpg)](https://www.youtube.com/watch?v=5fzzEx7-a5k)

--- a/lib/common.js
+++ b/lib/common.js
@@ -79,35 +79,6 @@ const linkProviders = [{
   },
 }];
 
-// /**
-//  *
-//  * @param {*} nodes an array of mdast nodes (markdown nodes)
-//  * @returns array of nodes, with link nodes transformed
-//  */
-// const transformLinks = nodes => nodes.map((node) => {
-//   if (node.type !== 'link') {
-//     return node;
-//   }
-//   const urlObj = url.parse(node.url);
-//   const qs = queryString.parse(urlObj.query);
-//   const provider = linkProviders.find(item => item.test(urlObj, qs));
-
-//   if (!provider) {
-//     return node;
-//   }
-
-//   // at this point the nodes are of mdast markdown
-//   // and if we want to transform to an iframe
-//   // we can only do node type html https://github.com/syntax-tree/mdast#nodes
-//   // example {type: 'html', value: '<div>'}
-
-//   // TODO use children text for alt tag ?
-//   // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
-//   const iframeNode = { ...node, type: 'html', value: provider.getHTML(urlObj) };
-//   console.log(iframeNode);
-//   return iframeNode;
-// });
-
 const transformLink = (node) => {
   if (node.type !== 'link') {
     return node;
@@ -127,9 +98,9 @@ const transformLink = (node) => {
 
   // TODO use children text for alt tag ?
   // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
-  const iframeNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
-  console.log(iframeNode);
-  return iframeNode;
+  const htmlNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
+  console.log(htmlNode);
+  return htmlNode;
 };
 
 export const parser = unified()
@@ -325,20 +296,6 @@ export const parseReadmes = async (dir, langs, type, fn) => {
         const [metaText, contentText] = splitMetaAndContent(trimmed);
         const rootNode = parser.parse(contentText);
 
-        // TODO: analice y reemplace links a proveedores como
-        // YouTube, Vimeo, Loom, Google Slides, etc en el body de los archivos markdown analizados
-
-        // eslint-disable-next-line no-unused-vars
-        // const getAllChildNodes = (node) => {
-        //   if (node.children?.length) {
-        //     // eslint-disable-next-line arrow-body-style
-        //     return node.children.reduce((memo, n) => {
-        //       return [...memo, n, ...getAllChildNodes(n)];
-        //     }, []);
-        //   }
-        //   return [node];
-        // };
-
         const parseLinks = (node) => {
           if (node.type === 'link') {
             const linkProps = transformLink(node);
@@ -350,11 +307,6 @@ export const parseReadmes = async (dir, langs, type, fn) => {
           // console.log(node);
           return node;
         };
-        // TODO use link providers to change Youtube
-        // https://github.com/Laboratoria/curriculum-parser/blob/941eab7e5ce9aa97f165f34c9f8253552c1a5dec/lib/common.js#L56
-
-        // const nodes = transformLinks(getAllChildNodes(rootNode));
-        // console.log(nodes); // does this replace the value of parsedRootNode?
 
         const meta = (
           !metaText

--- a/lib/common.js
+++ b/lib/common.js
@@ -2,19 +2,123 @@ import { deepStrictEqual } from 'node:assert';
 import { Buffer } from 'node:buffer';
 import { existsSync } from 'node:fs';
 import { stat, readFile, writeFile, readdir } from 'node:fs/promises';
-import path from 'node:path';
 import https from 'node:https';
+import path from 'node:path';
+import queryString from 'node:querystring';
+import url from 'node:url';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
+// import rehypeRewrite from 'rehype-rewrite';
 import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
 import sharp from 'sharp';
 import yaml from 'js-yaml';
 
+
+const linkProviders = [{
+  id: 'vimeo',
+  test: urlObj => urlObj.hostname === 'vimeo.com',
+  // getObject: (linkNode, urlObj) => ({
+  //   type: 'video',
+  //   provider: 'vimeo',
+  //   href: linkNode.url,
+  //   id: urlObj.pathname.slice(1),
+  // }),
+  getNodeProperties: (linkNode, urlObj) => {
+    const videoId = urlObj.pathname.slice(1);
+    const qs = queryString.encode({
+      title: 0,
+      byline: 0,
+      portrait: 0,
+      ...queryString.decode(urlObj.query),
+    });
+    const src = `https://player.vimeo.com/video/${videoId}?${qs}`;
+    /*
+    const el = Object.assign(document.createElement('iframe'), {
+      width: 640,
+      height: 360,
+      src,
+      frameBorder: '0',
+      scrolling: 'no',
+    });
+    el.setAttribute('allowfullscreen', 'true');
+    el.setAttribute('mozallowfullscreen', 'true');
+    el.setAttribute('webkitallowfullscreen', 'true');
+    return el;
+    if(node.type == 'text' && node.value == 'header') {
+      node.value = ''
+    }
+    */
+    // eslint-disable-next-line no-param-reassign
+    return {
+      tagName: 'iframe',
+      properties: {
+        ...linkNode.properties,
+        width: 640,
+        height: 360,
+        src,
+        frameBorder: '0',
+        scrolling: 'no',
+        allowfullscreen: 'true',
+        mozallowfullscreen: 'true',
+        webkitallowfullscreen: 'true',
+      },
+    };
+  },
+},
+{
+  id: 'youtube',
+  test: (urlObj, qs) => (
+    urlObj.hostname === 'youtu.be'
+    || (
+      urlObj.hostname === 'www.youtube.com'
+      && urlObj.pathname === '/watch'
+      && qs.v
+    )
+  ),
+  getObject: (a, urlObj, qs) => ({
+    type: 'video',
+    provider: 'youtube',
+    href: a.href,
+    id: urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : qs.v,
+  }),
+  getElement: () => {},
+}];
+
+const transformLink = (linkNode) => {
+  // https://github.com/syntax-tree/hast#element
+  // https://github.com/syntax-tree/mdast
+  // if (node.type === 'link') {
+  const urlObj = url.parse(linkNode.properties.href);
+  const qs = queryString.parse(urlObj.query);
+  const provider = linkProviders.find(item => item.test(urlObj, qs));
+
+  if (provider) {
+    Object.assign(linkNode, provider.getNodeProperties(linkNode, urlObj));
+    console.log(linkNode);
+  }
+};
+
+const visitLinkNodes = () => (tree) => {
+  // worth putting visitor test here?
+  // https://www.npmjs.com/package/unist-util-visit#test
+  visit(tree, node => (node.type === 'element' && node.tagName === 'a'), transformLink);
+  // (node) => {
+  // if (node.tagName === 'a') {
+  // rewriteLink(node);
+  // }
+  // })
+};
+
 export const parser = unified()
   .use(remarkParse)
+  // .use(rehypeRewrite, {
+  //   rewrite: rewriteLink,
+  // })
   .use(remarkRehype)
-  .use(rehypeStringify);
+  .use(rehypeStringify)
+  .use(visitLinkNodes);
 
 export const parseDirname = (dir) => {
   const basename = path.basename(dir);
@@ -203,6 +307,29 @@ export const parseReadmes = async (dir, langs, type, fn) => {
 
         const [metaText, contentText] = splitMetaAndContent(trimmed);
         const rootNode = parser.parse(contentText);
+
+        // TODO: analice y reemplace links a proveedores como
+        // YouTube, Vimeo, Loom, Google Slides, etc en el body de los archivos markdown analizados
+
+        // eslint-disable-next-line no-unused-vars
+        const getAllChildNodes = (node) => {
+          if (node.children?.length) {
+            // eslint-disable-next-line arrow-body-style
+            return node.children.reduce((memo, n) => {
+              return [...memo, n, ...getAllChildNodes(n)];
+            }, []);
+          }
+          return [node];
+        };
+        // const links = getAllChildNodes(rootNode).filter(node => node.type === 'link');
+        // console.log(links);
+        // instead of filter maybe should iterate through child nodes and when link
+        // replace / rewrite node
+
+        // links.forEach(link => parseLink(rootNode, link));
+        // TODO use link providers to change Youtube
+        // https://github.com/Laboratoria/curriculum-parser/blob/941eab7e5ce9aa97f165f34c9f8253552c1a5dec/lib/common.js#L56
+
         const meta = (
           !metaText
             ? null

--- a/lib/common.js
+++ b/lib/common.js
@@ -4,103 +4,13 @@ import { existsSync } from 'node:fs';
 import { stat, readFile, writeFile, readdir } from 'node:fs/promises';
 import https from 'node:https';
 import path from 'node:path';
-import queryString from 'node:querystring';
-import url from 'node:url';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
 import sharp from 'sharp';
 import yaml from 'js-yaml';
-
-
-const linkProviders = [{
-  id: 'vimeo',
-  test: urlObj => urlObj.hostname === 'vimeo.com',
-  // getObject: (linkNode, urlObj) => ({
-  //   type: 'video',
-  //   provider: 'vimeo',
-  //   href: linkNode.url,
-  //   id: urlObj.pathname.slice(1),
-  // }),
-  getHTML: (urlObj) => {
-    const videoId = urlObj.pathname.slice(1);
-    const qs = queryString.encode({
-      title: 0,
-      byline: 0,
-      portrait: 0,
-      ...queryString.decode(urlObj.query),
-    });
-    const src = `https://player.vimeo.com/video/${videoId}?${qs}`;
-
-    const attributes = {
-      width: 640,
-      height: 360,
-      src,
-      frameBorder: '0',
-      scrolling: 'no',
-      allowfullscreen: 'true',
-      mozallowfullscreen: 'true',
-      webkitallowfullscreen: 'true',
-    };
-
-    return `<iframe ${Object.entries(attributes).map(([key, value]) => `${key}="${value}"`).join(' ')}></iframe>`;
-  },
-},
-{
-  id: 'youtube',
-  test: (urlObj, qs) => (
-    urlObj.hostname === 'youtu.be'
-    || (
-      urlObj.hostname === 'www.youtube.com'
-      && urlObj.pathname === '/watch'
-      && qs.v
-    )
-  ),
-  getObject: (a, urlObj, qs) => ({
-    type: 'video',
-    provider: 'youtube',
-    href: a.href,
-    id: urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : qs.v,
-  }),
-  getHTML: (urlObj, { v, ...qs }) => {
-    const videoId = urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : v;
-    const params = queryString.stringify({ ...qs, autoplay: 0 });
-    const attributes = {
-      width: 640,
-      height: 360,
-      src: `https://www.youtube.com/embed/${videoId}?${params}`,
-      frameBorder: '0',
-      gesture: 'media',
-      allow: 'encrypted-media',
-      allowfullscreen: 'true',
-    };
-    return `<iframe ${Object.entries(attributes).map(([key, value]) => `${key}="${value}"`).join(' ')}></iframe>`;
-  },
-}];
-
-const transformLink = (node) => {
-  if (node.type !== 'link') {
-    return node;
-  }
-  const urlObj = url.parse(node.url);
-  const qs = queryString.parse(urlObj.query);
-  const provider = linkProviders.find(item => item.test(urlObj, qs));
-
-  if (!provider) {
-    return node;
-  }
-
-  // at this point the nodes are of mdast markdown
-  // and if we want to transform to an iframe
-  // we can only do node type html https://github.com/syntax-tree/mdast#nodes
-  // example {type: 'html', value: '<div>'}
-
-  // TODO use children text for alt tag ?
-  // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
-  const htmlNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
-  return htmlNode;
-};
+import { parseLinks } from './linkProviders.js';
 
 export const parser = unified()
   .use(remarkParse)
@@ -294,18 +204,6 @@ export const parseReadmes = async (dir, langs, type, fn) => {
 
         const [metaText, contentText] = splitMetaAndContent(trimmed);
         const rootNode = parser.parse(contentText);
-
-        // eslint-disable-next-line no-unused-vars
-        const parseLinks = (node) => {
-          if (node.type === 'link') {
-            const linkProps = transformLink(node);
-            Object.assign(node, linkProps);
-          }
-          if (node.children?.length) {
-            return ({ ...node, children: node.children.map(n => parseLinks(n)) });
-          }
-          return node;
-        };
 
         const meta = (
           !metaText

--- a/lib/common.js
+++ b/lib/common.js
@@ -9,9 +9,7 @@ import url from 'node:url';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
-// import rehypeRewrite from 'rehype-rewrite';
 import rehypeStringify from 'rehype-stringify';
-import { visit } from 'unist-util-visit';
 import sharp from 'sharp';
 import yaml from 'js-yaml';
 
@@ -25,7 +23,7 @@ const linkProviders = [{
   //   href: linkNode.url,
   //   id: urlObj.pathname.slice(1),
   // }),
-  getNodeProperties: (linkNode, urlObj) => {
+  getHTML: (urlObj) => {
     const videoId = urlObj.pathname.slice(1);
     const qs = queryString.encode({
       title: 0,
@@ -34,37 +32,19 @@ const linkProviders = [{
       ...queryString.decode(urlObj.query),
     });
     const src = `https://player.vimeo.com/video/${videoId}?${qs}`;
-    /*
-    const el = Object.assign(document.createElement('iframe'), {
+
+    const attributes = {
       width: 640,
       height: 360,
       src,
       frameBorder: '0',
       scrolling: 'no',
-    });
-    el.setAttribute('allowfullscreen', 'true');
-    el.setAttribute('mozallowfullscreen', 'true');
-    el.setAttribute('webkitallowfullscreen', 'true');
-    return el;
-    if(node.type == 'text' && node.value == 'header') {
-      node.value = ''
-    }
-    */
-    // eslint-disable-next-line no-param-reassign
-    return {
-      tagName: 'iframe',
-      properties: {
-        ...linkNode.properties,
-        width: 640,
-        height: 360,
-        src,
-        frameBorder: '0',
-        scrolling: 'no',
-        allowfullscreen: 'true',
-        mozallowfullscreen: 'true',
-        webkitallowfullscreen: 'true',
-      },
+      allowfullscreen: 'true',
+      mozallowfullscreen: 'true',
+      webkitallowfullscreen: 'true',
     };
+
+    return `<iframe ${Object.entries(attributes).map(([key, value]) => `${key}="${value}"`).join(' ')}></iframe>`;
   },
 },
 {
@@ -83,42 +63,79 @@ const linkProviders = [{
     href: a.href,
     id: urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : qs.v,
   }),
-  getElement: () => {},
+  getHTML: (urlObj, { v, ...qs }) => {
+    const videoId = urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : v;
+    const params = queryString.stringify({ ...qs, autoplay: 0 });
+    const attributes = {
+      width: 640,
+      height: 360,
+      src: `https://www.youtube.com/embed/${videoId}?${params}`,
+      frameBorder: '0',
+      gesture: 'media',
+      allow: 'encrypted-media',
+      allowfullscreen: 'true',
+    };
+    return `<iframe ${Object.entries(attributes).map(([key, value]) => `${key}="${value}"`).join(' ')}></iframe>`;
+  },
 }];
 
-const transformLink = (linkNode) => {
-  // https://github.com/syntax-tree/hast#element
-  // https://github.com/syntax-tree/mdast
-  // if (node.type === 'link') {
-  const urlObj = url.parse(linkNode.properties.href);
+// /**
+//  *
+//  * @param {*} nodes an array of mdast nodes (markdown nodes)
+//  * @returns array of nodes, with link nodes transformed
+//  */
+// const transformLinks = nodes => nodes.map((node) => {
+//   if (node.type !== 'link') {
+//     return node;
+//   }
+//   const urlObj = url.parse(node.url);
+//   const qs = queryString.parse(urlObj.query);
+//   const provider = linkProviders.find(item => item.test(urlObj, qs));
+
+//   if (!provider) {
+//     return node;
+//   }
+
+//   // at this point the nodes are of mdast markdown
+//   // and if we want to transform to an iframe
+//   // we can only do node type html https://github.com/syntax-tree/mdast#nodes
+//   // example {type: 'html', value: '<div>'}
+
+//   // TODO use children text for alt tag ?
+//   // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
+//   const iframeNode = { ...node, type: 'html', value: provider.getHTML(urlObj) };
+//   console.log(iframeNode);
+//   return iframeNode;
+// });
+
+const transformLink = (node) => {
+  if (node.type !== 'link') {
+    return node;
+  }
+  const urlObj = url.parse(node.url);
   const qs = queryString.parse(urlObj.query);
   const provider = linkProviders.find(item => item.test(urlObj, qs));
 
-  if (provider) {
-    Object.assign(linkNode, provider.getNodeProperties(linkNode, urlObj));
-    console.log(linkNode);
+  if (!provider) {
+    return node;
   }
-};
 
-const visitLinkNodes = () => (tree) => {
-  // worth putting visitor test here?
-  // https://www.npmjs.com/package/unist-util-visit#test
-  visit(tree, node => (node.type === 'element' && node.tagName === 'a'), transformLink);
-  // (node) => {
-  // if (node.tagName === 'a') {
-  // rewriteLink(node);
-  // }
-  // })
+  // at this point the nodes are of mdast markdown
+  // and if we want to transform to an iframe
+  // we can only do node type html https://github.com/syntax-tree/mdast#nodes
+  // example {type: 'html', value: '<div>'}
+
+  // TODO use children text for alt tag ?
+  // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
+  const iframeNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
+  console.log(iframeNode);
+  return iframeNode;
 };
 
 export const parser = unified()
   .use(remarkParse)
-  // .use(rehypeRewrite, {
-  //   rewrite: rewriteLink,
-  // })
-  .use(remarkRehype)
-  .use(rehypeStringify)
-  .use(visitLinkNodes);
+  .use(remarkRehype, { allowDangerousHtml: true }) // https://github.com/remarkjs/remark-rehype/issues/8#issuecomment-309298870
+  .use(rehypeStringify, { allowDangerousHtml: true });
 
 export const parseDirname = (dir) => {
   const basename = path.basename(dir);
@@ -312,31 +329,41 @@ export const parseReadmes = async (dir, langs, type, fn) => {
         // YouTube, Vimeo, Loom, Google Slides, etc en el body de los archivos markdown analizados
 
         // eslint-disable-next-line no-unused-vars
-        const getAllChildNodes = (node) => {
-          if (node.children?.length) {
-            // eslint-disable-next-line arrow-body-style
-            return node.children.reduce((memo, n) => {
-              return [...memo, n, ...getAllChildNodes(n)];
-            }, []);
-          }
-          return [node];
-        };
-        // const links = getAllChildNodes(rootNode).filter(node => node.type === 'link');
-        // console.log(links);
-        // instead of filter maybe should iterate through child nodes and when link
-        // replace / rewrite node
+        // const getAllChildNodes = (node) => {
+        //   if (node.children?.length) {
+        //     // eslint-disable-next-line arrow-body-style
+        //     return node.children.reduce((memo, n) => {
+        //       return [...memo, n, ...getAllChildNodes(n)];
+        //     }, []);
+        //   }
+        //   return [node];
+        // };
 
-        // links.forEach(link => parseLink(rootNode, link));
+        const parseLinks = (node) => {
+          if (node.type === 'link') {
+            const linkProps = transformLink(node);
+            Object.assign(node, linkProps);
+          }
+          if (node.children?.length) {
+            return ({ ...node, children: node.children.map(n => parseLinks(n)) });
+          }
+          // console.log(node);
+          return node;
+        };
         // TODO use link providers to change Youtube
         // https://github.com/Laboratoria/curriculum-parser/blob/941eab7e5ce9aa97f165f34c9f8253552c1a5dec/lib/common.js#L56
+
+        // const nodes = transformLinks(getAllChildNodes(rootNode));
+        // console.log(nodes); // does this replace the value of parsedRootNode?
 
         const meta = (
           !metaText
             ? null
             : { ...yaml.load(metaText), __source: 'inline' }
         );
-        const parsedRootNode = await fn(rootNode, meta);
 
+        const parsedRootNode = await fn(parseLinks(rootNode), meta);
+        // const parsedRootNode = await fn(rootNode, meta);
         return [parsedRootNode, meta, rootNode];
       } catch (err) {
         throw Object.assign(err, { path: err.path || path.join(dir, fname) });

--- a/lib/common.js
+++ b/lib/common.js
@@ -99,7 +99,6 @@ const transformLink = (node) => {
   // TODO use children text for alt tag ?
   // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
   const htmlNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
-  console.log(htmlNode);
   return htmlNode;
 };
 
@@ -296,6 +295,7 @@ export const parseReadmes = async (dir, langs, type, fn) => {
         const [metaText, contentText] = splitMetaAndContent(trimmed);
         const rootNode = parser.parse(contentText);
 
+        // eslint-disable-next-line no-unused-vars
         const parseLinks = (node) => {
           if (node.type === 'link') {
             const linkProps = transformLink(node);
@@ -304,7 +304,6 @@ export const parseReadmes = async (dir, langs, type, fn) => {
           if (node.children?.length) {
             return ({ ...node, children: node.children.map(n => parseLinks(n)) });
           }
-          // console.log(node);
           return node;
         };
 
@@ -313,7 +312,6 @@ export const parseReadmes = async (dir, langs, type, fn) => {
             ? null
             : { ...yaml.load(metaText), __source: 'inline' }
         );
-
         const parsedRootNode = await fn(parseLinks(rootNode), meta);
         // const parsedRootNode = await fn(rootNode, meta);
         return [parsedRootNode, meta, rootNode];

--- a/lib/linkProviders.js
+++ b/lib/linkProviders.js
@@ -1,0 +1,107 @@
+import queryString from 'node:querystring';
+import url from 'node:url';
+
+const getAttributeString = attrsObject => Object.entries(attrsObject).map(([k, v]) => `${k}="${v}"`).join(' ');
+
+const linkProviders = [{
+  id: 'vimeo',
+  test: urlObj => urlObj.hostname === 'vimeo.com',
+  // getObject: (linkNode, urlObj) => ({
+  //   type: 'video',
+  //   provider: 'vimeo',
+  //   href: linkNode.url,
+  //   id: urlObj.pathname.slice(1),
+  // }),
+  getHTML: (urlObj) => {
+    const videoId = urlObj.pathname.slice(1);
+    const qs = queryString.encode({
+      title: 0,
+      byline: 0,
+      portrait: 0,
+      ...queryString.decode(urlObj.query),
+    });
+    const src = `https://player.vimeo.com/video/${videoId}?${qs}`;
+    const attributes = {
+      width: 640,
+      height: 360,
+      src,
+      frameBorder: '0',
+      scrolling: 'no',
+      allowfullscreen: 'true',
+      mozallowfullscreen: 'true',
+      webkitallowfullscreen: 'true',
+    };
+
+    return `<iframe ${getAttributeString(attributes)}></iframe>`;
+  },
+},
+{
+  id: 'youtube',
+  test: (urlObj, qs) => (
+    urlObj.hostname === 'youtu.be'
+    || (
+      urlObj.hostname === 'www.youtube.com'
+      && urlObj.pathname === '/watch'
+      && qs.v
+    )
+  ),
+  // getObject: (a, urlObj, qs) => ({
+  //   type: 'video',
+  //   provider: 'youtube',
+  //   href: a.href,
+  //   id: urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : qs.v,
+  // }),
+  getHTML: (urlObj, { v, ...qs }) => {
+    const videoId = urlObj.hostname === 'youtu.be' ? urlObj.pathname.slice(1) : v;
+    const params = queryString.stringify({ ...qs, autoplay: 0 });
+    const attributes = {
+      width: 640,
+      height: 360,
+      src: `https://www.youtube.com/embed/${videoId}?${params}`,
+      frameBorder: '0',
+      gesture: 'media',
+      allow: 'encrypted-media',
+      allowfullscreen: 'true',
+    };
+    return `<iframe ${getAttributeString(attributes)}></iframe>`;
+  },
+}];
+
+const transformLink = (node) => {
+  const urlObj = url.parse(node.url);
+  const qs = queryString.parse(urlObj.query);
+  const provider = linkProviders.find(item => item.test(urlObj, qs));
+
+  if (!provider) {
+    return node;
+  }
+
+  // at this point the nodes are mdast markdown
+  // and if we want to transform to an iframe
+  // we have to set the node to type html https://github.com/syntax-tree/mdast#nodes
+  // with the value of the raw html
+  // example {type: 'html', value: '<div>'}
+
+  // TODO use children text for alt tag ?
+  // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
+  const htmlNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
+  return htmlNode;
+};
+
+export const parseLinks = (node) => {
+  if (node.type === 'link') {
+    const linkProps = transformLink(node);
+    Object.assign(node, linkProps);
+  }
+  if (node.children?.length) {
+    // return { ...node, children: node.children.map(n => parseLinks(n)) };
+
+    /* for testing */
+    const nn = { ...node, children: node.children.map(n => parseLinks(n)) };
+    if (nn.type === 'html') {
+      // console.log(nn, nn.value);
+    }
+    return nn;
+  }
+  return node;
+};

--- a/lib/linkProviders.js
+++ b/lib/linkProviders.js
@@ -5,7 +5,8 @@ const getAttributeString = attrsObject => Object.entries(attrsObject).map(([k, v
 
 const linkProviders = [{
   id: 'vimeo',
-  test: urlObj => urlObj.hostname === 'vimeo.com',
+  // this second test allows us to skip vimeo links with the unique format /id/id
+  test: urlObj => urlObj.hostname === 'vimeo.com' && urlObj.path.replace(/^\/|\/$/g, '').split('/').length <= 1,
   // getObject: (linkNode, urlObj) => ({
   //   type: 'video',
   //   provider: 'vimeo',
@@ -76,13 +77,14 @@ const transformLink = (node) => {
     return node;
   }
 
-  // at this point the nodes are mdast markdown
+  // Note: at this point the nodes are mdast markdown
   // and if we want to transform to an iframe
   // we have to set the node to type html https://github.com/syntax-tree/mdast#nodes
   // with the value of the raw html
   // example {type: 'html', value: '<div>'}
 
-  // TODO use children text for alt tag ?
+  // TODO use children text for iframe title
+  // https://www.boia.org/blog/why-are-iframe-titles-important-for-accessibility
   // TODO put in iframe container https://github.com/Laboratoria/curriculum-parser/blob/main/lib/common.js#L315
   const htmlNode = { ...node, type: 'html', value: provider.getHTML(urlObj, qs) };
   return htmlNode;
@@ -94,14 +96,14 @@ export const parseLinks = (node) => {
     Object.assign(node, linkProps);
   }
   if (node.children?.length) {
-    // return { ...node, children: node.children.map(n => parseLinks(n)) };
+    return { ...node, children: node.children.map(n => parseLinks(n)) };
 
-    /* for testing */
-    const nn = { ...node, children: node.children.map(n => parseLinks(n)) };
-    if (nn.type === 'html') {
-      // console.log(nn, nn.value);
+    /* for testing
+    const newNode = { ...node, children: node.children.map(n => parseLinks(n)) };
+    if (newNode.type === 'html') {
+      console.log(newNode, newNode.value);
     }
-    return nn;
+    return newNode; */
   }
   return node;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "js-yaml": "^4.1.0",
         "rehype-document": "^6.1.0",
+        "rehype-rewrite": "^3.0.6",
         "rehype-stringify": "^9.0.3",
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",
-        "sharp": "^0.31.3",
-        "unified": "^10.1.2"
+        "sharp": "0.31.1",
+        "unified": "^10.1.2",
+        "unist-util-visit": "^4.1.2"
       },
       "bin": {
         "curriculum-parser": "index.js"
@@ -857,6 +859,15 @@
         }
       ]
     },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -866,6 +877,11 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1197,6 +1213,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1301,6 +1322,18 @@
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -2099,6 +2132,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hast-util-has-property": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.1.tgz",
+      "integrity": "sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
@@ -2124,6 +2166,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-select": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-5.0.5.tgz",
+      "integrity": "sha512-QQhWMhgTFRhCaQdgTKzZ5g31GLQ9qRb1hZtDPMqQaOhpLBziWcshUS0uCR5IJ0U1jrK/mxg35fmcq+Dp/Cy2Aw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-to-string": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.3.tgz",
@@ -2139,6 +2207,18 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.2",
         "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3325,6 +3405,22 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
     },
+    "node_modules/not": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
+      "integrity": "sha512-5PDmaAsVfnWUgTUbJ3ERwn7u79Z0dYxN9ErxCpVJJqe2RK0PJ3z+iFUxuqjwtlDDegXvtWoxD/3Fzxox7tFGWA=="
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -3722,6 +3818,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-rewrite": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-3.0.6.tgz",
+      "integrity": "sha512-REDTNCvsKcAazy8IQWzKp66AhSUDSOIKssSCqNqCcT9sN7JCwAAm3mWGTUdUzq80ABuy8d0D6RBwbnewu1aY1g==",
+      "dependencies": {
+        "hast-util-select": "~5.0.1",
+        "unified": "~10.1.1",
+        "unist-util-visit": "~4.1.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/rehype-stringify": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
@@ -3911,16 +4020,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.3.tgz",
-      "integrity": "sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.1",
         "node-addon-api": "^5.0.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.3.7",
         "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
@@ -4488,9 +4597,9 @@
       }
     },
     "node_modules/unist-util-visit": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
-      "integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -4867,6 +4976,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   },
@@ -5374,6 +5492,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -5383,6 +5506,11 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -5619,6 +5747,11 @@
         "which": "^2.0.1"
       }
     },
+    "css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5685,6 +5818,11 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+    },
+    "direction": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
+      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -6280,6 +6418,11 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hast-util-has-property": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.1.tgz",
+      "integrity": "sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg=="
+    },
     "hast-util-is-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
@@ -6297,6 +6440,28 @@
         "@types/hast": "^2.0.0"
       }
     },
+    "hast-util-select": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-5.0.5.tgz",
+      "integrity": "sha512-QQhWMhgTFRhCaQdgTKzZ5g31GLQ9qRb1hZtDPMqQaOhpLBziWcshUS0uCR5IJ0U1jrK/mxg35fmcq+Dp/Cy2Aw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0",
+        "bcp-47-match": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "css-selector-parser": "^1.0.0",
+        "direction": "^2.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-to-string": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
+      }
+    },
     "hast-util-to-html": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.3.tgz",
@@ -6312,6 +6477,14 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.2",
         "unist-util-is": "^5.0.0"
+      }
+    },
+    "hast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==",
+      "requires": {
+        "@types/hast": "^2.0.0"
       }
     },
     "hast-util-whitespace": {
@@ -7046,6 +7219,19 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
     },
+    "not": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
+      "integrity": "sha512-5PDmaAsVfnWUgTUbJ3ERwn7u79Z0dYxN9ErxCpVJJqe2RK0PJ3z+iFUxuqjwtlDDegXvtWoxD/3Fzxox7tFGWA=="
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
+    },
     "object-inspect": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
@@ -7317,6 +7503,16 @@
         "unified": "^10.0.0"
       }
     },
+    "rehype-rewrite": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/rehype-rewrite/-/rehype-rewrite-3.0.6.tgz",
+      "integrity": "sha512-REDTNCvsKcAazy8IQWzKp66AhSUDSOIKssSCqNqCcT9sN7JCwAAm3mWGTUdUzq80ABuy8d0D6RBwbnewu1aY1g==",
+      "requires": {
+        "hast-util-select": "~5.0.1",
+        "unified": "~10.1.1",
+        "unist-util-visit": "~4.1.0"
+      }
+    },
     "rehype-stringify": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
@@ -7428,15 +7624,15 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "sharp": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.3.tgz",
-      "integrity": "sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
       "requires": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.1",
         "node-addon-api": "^5.0.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.3.7",
         "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"
@@ -7832,9 +8028,9 @@
       }
     },
     "unist-util-visit": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
-      "integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -8064,6 +8260,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "js-yaml": "^4.1.0",
     "rehype-document": "^6.1.0",
+    "rehype-rewrite": "^3.0.6",
     "rehype-stringify": "^9.0.3",
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",
-    "sharp": "^0.31.3",
-    "unified": "^10.1.2"
+    "sharp": "0.31.1",
+    "unified": "^10.1.2",
+    "unist-util-visit": "^4.1.2"
   },
   "devDependencies": {
     "@vitest/coverage-c8": "^0.29.2",


### PR DESCRIPTION
Uso de `linkProviders` para generar markup de markdown con previews de links (iframes, etc)

En lugar de tener links "calata" en la pagina, este codigo es responsable a generar un "thumbnail" (iframe)

Un ejemplo de output de parser ahora:
https://gist.github.com/unjust/12183fb20f046cf363084d59d37a310e

Y un ejemplo de como parece en el proyecto bootcamp
https://github.com/Laboratoria/curriculum-parser/pull/66#issuecomment-1474561380

En esta rama tenemos linkProviders para Vimeo y YouTube.

* [ ] manejar links que no queremos hacer iframe https://github.com/unjust/curriculum-parser/pull/1
* [ ] Testear con screen reader
* [ ] Documentar feature en release notes
____

Subido un spec para probar Youtube y Vimeo. Algunos casos preguntas viendo otros READMEs:

* [ En estes casos](https://github.com/Laboratoria/curriculum-parser/blob/v5.x/lib/__tests__/__fixtures__/README-with-youtube-with-params.md?plain=1#L30) - que tiene thumbnail image y link, si es de Youtube o Vimeo, preferimos hacer el iframe en lugar de thumbnail. este tiene el efecto de reemplazar los thumbnails con el player en casos que sean videos de Youtube o Vimeo (estamos en acuerdo?)

<img width="786" alt="Screen Shot 2023-04-14 at 4 04 21 PM" src="https://user-images.githubusercontent.com/92090/232154657-64aa7f34-05ea-42fa-a8cf-74f71aa0dc68.png">

* En el codigo agregue logica para saltar los links de vimeo con raro formato `https://vimeo.com/503607618/7619450015` (Aprender aprender)? el iframe no funciona. es un edge case, no se si necesitamos logica o lo quito.

____

Para verlo en action:

1. En Visual Studio Code crear un `launch.json` (toca el bug icono para activar el depurador y deberia ayudarte crear un `launch.json` para node)
2. En el `launch.json` [agrega eso](https://gist.github.com/unjust/ae0a40d8a4dc20eebd111592d655a236) a propiedad `configurations`
3. Crea [un nuevo fixture con links](https://gist.github.com/unjust/03161c646e2ecb230fb7fda984bebe37) en este path `lib/__tests__/__fixtures__/04-readme-with-links` (esta referenciado en el `launch.json` - si cambias la ruta cambia en el launch tambien)
4. Agrega algunos punto de interupción en `common.js` (tipo [L315](https://github.com/Laboratoria/curriculum-parser/pull/66/files#diff-ce403d6ec5029de295afb2ce2cd750756ec521b775ea915839260a778f8772ebR315), L27)
5. Corre el depurador y observar cuando para a los nodos que tiene type `link`
6. 
Pregunta: Tenemos que cambiar los fixtures o todo bien? No podia correr el curriculum parser con readmes individual, tuve que usar los directorios como puntos de entrada. No se como puedo usar los readmes directo con el comando de parser.